### PR TITLE
Add timeout for Vectara calls

### DIFF
--- a/langchain/src/vectorstores/vectara.ts
+++ b/langchain/src/vectorstores/vectara.ts
@@ -58,6 +58,8 @@ export class VectaraStore extends VectorStore {
 
   private verbose: boolean;
 
+  private vectaraApiTimeout = 60;
+
   _vectorstoreType(): string {
     return "vectara";
   }
@@ -130,11 +132,15 @@ export class VectaraStore extends VectorStore {
       };
 
       try {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), this.vectaraApiTimeout * 1000);
         const response = await fetch(`https://${this.apiEndpoint}/v1/index`, {
           method: "POST",
           headers: headers?.headers,
           body: JSON.stringify(data),
+          signal: controller.signal,
         });
+        clearTimeout(timeout);
         const result = await response.json();
         if (
           result.status?.code !== "OK" &&
@@ -186,11 +192,15 @@ export class VectaraStore extends VectorStore {
       ],
     };
 
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.vectaraApiTimeout * 1000);
     const response = await fetch(`https://${this.apiEndpoint}/v1/query`, {
       method: "POST",
       headers: headers?.headers,
       body: JSON.stringify(data),
+      signal: controller.signal,
     });
+    clearTimeout(timeout);
     if (response.status !== 200) {
       throw new Error(`Vectara API returned status code ${response.status}`);
     }
@@ -202,12 +212,12 @@ export class VectaraStore extends VectorStore {
         metadata: Record<string, unknown>;
         score: number;
       }) => [
-        new Document({
-          pageContent: response.text,
-          metadata: response.metadata,
-        }),
-        response.score,
-      ]
+          new Document({
+            pageContent: response.text,
+            metadata: response.metadata,
+          }),
+          response.score,
+        ]
     );
     return documentsAndScores;
   }


### PR DESCRIPTION
<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/hwchase17/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/hwchase17/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

The default fetch API does not have the timeout property so I used the setTimeout function instead.