### PR TITLE
Add document metadata

### DIFF
--- a/langchain/src/vectorstores/tests/vectara.int.test.ts
+++ b/langchain/src/vectorstores/tests/vectara.int.test.ts
@@ -123,6 +123,11 @@ describe("VectaraStore", () => {
       expect(resultsWithScore.length).toBeGreaterThan(0);
       expect(resultsWithScore[0][0].pageContent.length).toBeGreaterThan(0);
       expect(resultsWithScore[0][0].metadata.length).toBeGreaterThan(0);
+      expect(
+        resultsWithScore[0][0].metadata.find(
+          (item: { name: string }) => item.name === "title"
+        ).value
+      ).toBe("Lord of the Rings");
       expect(resultsWithScore[0][1]).toBeGreaterThan(0);
     });
 

--- a/langchain/src/vectorstores/vectara.ts
+++ b/langchain/src/vectorstores/vectara.ts
@@ -225,8 +225,29 @@ export class VectaraStore extends VectorStore {
     if (response.status !== 200) {
       throw new Error(`Vectara API returned status code ${response.status}`);
     }
+
     const result = await response.json();
     const responses = result.responseSet[0].response;
+    const documents = result.responseSet[0].document;
+
+    for (let i = 0; i < responses.length; i += 1) {
+      const responseMetadata = responses[i].metadata;
+      const documentMetadata = documents[responses[i].documentIndex].metadata;
+      const combinedMetadata: Record<string, unknown> = {};
+
+      responseMetadata.forEach((item: { name: string; value: unknown }) => {
+        combinedMetadata[item.name] = item.value;
+      });
+
+      documentMetadata.forEach((item: { name: string; value: unknown }) => {
+        combinedMetadata[item.name] = item.value;
+      });
+
+      responses[i].metadata = Object.entries(combinedMetadata).map(
+        ([name, value]) => ({ name, value })
+      );
+    }
+
     const documentsAndScores = responses.map(
       (response: {
         text: string;


### PR DESCRIPTION
This PR adds the document metadata to the response metadata object.

Metadata before this change (this is the response metadata only):
```
    [
      { name: 'lang', value: 'fra' },
      { name: 'offset', value: '218' },
      { name: 'len', value: '138' }
    ]
```

Metadata after this change (both document and response metadata are added):
```
    [
      { name: 'lang', value: 'fra' },
      { name: 'offset', value: '218' },
      { name: 'len', value: '138' },
      { name: 'document_id', value: '-1848969058' },
      { name: 'title', value: "The hitchhiker's guide to the galaxy" },
      { name: 'author', value: 'Douglas Adams' },
      { name: 'genre', value: 'fiction' }
    ]
```

The document metadata:
```
    [
      { name: 'document_id', value: '-1848969058' },
      { name: 'title', value: "The hitchhiker's guide to the galaxy" },
      { name: 'author', value: 'Douglas Adams' },
      { name: 'genre', value: 'fiction' },
      { name: 'lang', value: 'fra' }
    ]
```

The document and response metadata both have a lang property. For now I just kept one lang value for simplicity. Is this fine or should I create separate metadata objects for document and response? 