### PR TITLE
Make metadata an object instead of an array

### DIFF
--- a/langchain/src/vectorstores/tests/vectara.int.test.ts
+++ b/langchain/src/vectorstores/tests/vectara.int.test.ts
@@ -158,12 +158,11 @@ describe("VectaraStore", () => {
       );
       expect(results.length).toBeGreaterThan(0);
       expect(results[0].pageContent.length).toBeGreaterThan(0);
-      expect(results[0].metadata.length).toBeGreaterThan(0);
       // Query filtered on French, so we expect only French results
       const hasEnglish = results.some(
         (result) =>
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          result.metadata.find((m: any) => m.name === "lang")?.value === "eng"
+          result.metadata.lang === "eng"
       );
       expect(hasEnglish).toBe(false);
     });

--- a/langchain/src/vectorstores/vectara.ts
+++ b/langchain/src/vectorstores/vectara.ts
@@ -340,9 +340,7 @@ export class VectaraStore extends VectorStore {
         combinedMetadata[item.name] = item.value;
       });
 
-      responses[i].metadata = Object.entries(combinedMetadata).map(
-        ([name, value]) => ({ name, value })
-      );
+      responses[i].metadata = combinedMetadata;
     }
 
     const documentsAndScores = responses.map(


### PR DESCRIPTION
Before:
```
    [
      { name: 'lang', value: 'fra' },
      { name: 'section', value: '50' },
      { name: 'offset', value: '0' },
      { name: 'len', value: '34' },
      { name: 'CreationDate', value: '1237915995' },
      { name: 'Producer', value: 'OpenOffice.org 2.4' },
      { name: 'Creator', value: 'Writer' },
      {
        name: 'title',
        value: 'Bitcoin: A Peer-to-Peer Electronic Cash System'
      }
    ]
```


After:
```
    {
      lang: 'fra',
      section: '50',
      offset: '0',
      len: '34',
      CreationDate: '1237915995',
      Producer: 'OpenOffice.org 2.4',
      Creator: 'Writer',
      title: 'Bitcoin: A Peer-to-Peer Electronic Cash System'
    }
```

This PR introduces a breaking change. How should we document this?